### PR TITLE
Remove name property from token creation calls

### DIFF
--- a/docs/management-api-reference.http
+++ b/docs/management-api-reference.http
@@ -124,7 +124,6 @@ Authorization: {{$aadToken}}
 Content-Type: application/json; charset=utf-8
 
 {
-  "name": "{{tokenName}}",
   "properties": {
     "displayName": "{{tokenName}}"
   }

--- a/docs/management-api-reference.md
+++ b/docs/management-api-reference.md
@@ -230,7 +230,6 @@ A token can be created by requesting a `PUT` operation against `https://manageme
 
 ```json
 {
-  "name": "testtoken",
   "properties": {
     "displayName": "Test Dropbox token"
   }

--- a/docs/runtime-api-reference.md
+++ b/docs/runtime-api-reference.md
@@ -53,7 +53,6 @@ A token can be created by requesting a `PUT` operation against `https://[token-v
 
 ```json
 {
-  "name": "testtoken",
   "properties": {
     "displayName": "Test Dropbox token"
   }


### PR DESCRIPTION
`name` isn't needed since it's part of the endpoint route