### PR TITLE
Update vault to store for new naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,14 @@
 
-> Note: "Token Vault" for App Service is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like "Token Vault" are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
+> Note: Azure Token Store is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like Token Store are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
 
-# "Token Vault" for App Service
+# Azure Token Store
 
-"Token Vault" for App Service is a general purpose OAuth Token Management service for developers. It helps simplify the process of authenticating and authorizing users across SaaS services, thus reducing the level of investment needed in ramping up, implementing and maintaining security features.
+Azure Token Store is a general purpose OAuth Token Management service for developers. It helps simplify the process of authenticating and authorizing users across SaaS services, thus reducing the level of investment needed in ramping up, implementing and maintaining security features.
 
 # Let's get started!
 
-1. Send us **your Azure Subscription Id**, so we can onboard you in the "Token Vault" private preview.
-1. Once enrolled, **deploy your first "Token Vault"** for App Service by following [instructions on GitHub](https://github.com/joerob-msft/app-service-msi-tokenvault-dotnet).
+1. Send us **your Azure Subscription Id**, so we can onboard you in the Token Store private preview.
+1. Once enrolled, **deploy your first Token Store** for App Service by following [instructions on GitHub](https://github.com/joerob-msft/app-service-msi-tokenvault-dotnet).
     1. Deploy and use the Site on Azure.
     1. Clone, develop and debug locally, then deploy to Azure.
 1. **Send us feedback!** Either through our discussion alias (tokens@microsoft.com) or through [issues on GitHub](https://github.com/Azure/azure-tokens/issues).
@@ -23,38 +23,38 @@
 
 # Programming interfaces
 
-The service consists of two distinct REST-based Application Programming Interfaces (APIs), respectively for **management** and **runtime** operations. Both APIs are based on concepts of tokens, services, vaults and access policy as resources. Currently there are no client libraries available for the said REST-based APIs, but this is something we are thinking about for the future.
+The service consists of two distinct REST-based Application Programming Interfaces (APIs), respectively for **management** and **runtime** operations. Both APIs are based on concepts of tokens, services, stores and access policy as resources. Currently there are no client libraries available for the said REST-based APIs, but this is something we are thinking about for the future.
 
 ## Resources
 
 | Resource name | Parent resource | API availability | Supported actions |
 |---------------|---|--|---|
-| Vault | Resource group | Management | CreateOrUpdate, Read, Delete, List |
-| - Access policy | Vault | Management | CreateOrUpdate, Read, Delete, List |
-| - Service | Vault | Management, Runtime | CreateOrUpdate, Read, Delete, List |
+| Store | Resource group | Management | CreateOrUpdate, Read, Delete, List |
+| - Access policy | Store | Management | CreateOrUpdate, Read, Delete, List |
+| - Service | Store | Management, Runtime | CreateOrUpdate, Read, Delete, List |
 | - - Token | Service | Management, Runtime | CreateOrUpdate, Read, Delete, List, Login, Save, GetAccessToken |
 
 **Token** resource abstracts the data and functionality around OAuth 2.0 tokens. The user can perform login action on a specific token resource, which then abstracts the refresh and access tokens. The web application can then call the GetAccessToken action, and use the access token at runtime to call the external service on behalf of the user.
 
 **Service** resource represents a specific external service and its acoompanying authentication settings. We provide a list of managed service definitions that can be used to create a service resouce with minimal complexity. Usually client ID and client secret are the only parameters that need to be assigned upon service resource creation.
 
-**Vault** resource is a container of tokens and services, and represents the scope at which billing takes effect, as well as the scope at which Azure resource operations can be performed in ARM.
+**Store** resource is a container of tokens and services, and represents the scope at which billing takes effect, as well as the scope at which Azure resource operations can be performed in ARM.
 
-**Access policy** resources determine how security is applied to runtime operations. Access policies are inherited, i.e. those set at the Vault level apply to the actions (CreateOrUpdate, Read, Delete, List) on Service and Token resource. The principal of user who creates the vault is added with full access policy by default.
+**Access policy** resources determine how security is applied to runtime operations. Access policies are inherited, i.e. those set at the Store level apply to the actions (CreateOrUpdate, Read, Delete, List) on Service and Token resource. The principal of user who creates the store is added with full access policy by default.
 
 ## Runtime APIs
 
-The runtime APIs are available through a dedicated web address for each token vault. They support most of the resource management actions, however they also support the all-important token operations like get-access-token. They are meant for direct programmatic use and are more optimized for performance. The service host is `https://[token-vault-name].westcentralus.tokenvault.azure.net`.
+The runtime APIs are available through a dedicated web address for each token store. They support most of the resource management actions, however they also support the all-important token operations like get-access-token. They are meant for direct programmatic use and are more optimized for performance. The service host is `https://[token-store-name].westcentralus.tokenstore.azure.net`.
 
 See **[Runtime API reference](/docs/runtime-api-reference.md)** for more details.
 
 ## Management APIs (on Azure Resource Manager)
 
-The management APIs are primarily meant to enable uniform resource management along with other Azure resources, either through REST-based requests or through deployment templates. They are based on Azure Resource Management (ARM) and can be used for programmatic resource mangement actions like read, create, update, delete, list etc. The ARM interface also enables joint template deployment of "Token Vault" and other Azure resoruces, in form of full solutions. The web address for these APIs are under `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault`.
+The management APIs are primarily meant to enable uniform resource management along with other Azure resources, either through REST-based requests or through deployment templates. They are based on Azure Resource Management (ARM) and can be used for programmatic resource mangement actions like read, create, update, delete, list etc. The ARM interface also enables joint template deployment of Token Store and other Azure resoruces, in form of full solutions. The web address for these APIs are under `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token`.
 
 See **[Management API reference](/docs/management-api-reference.md)** for more details.
 
-*Vaults*, *access policies*, *services* are strictly managed by the developer. *Tokens* are also sometimes managed by the developer, however they can be assigned to, and accessed by users through the web application runtime, depending on the scenario.
+*Stores*, *access policies*, *services* are strictly managed by the developer. *Tokens* are also sometimes managed by the developer, however they can be assigned to, and accessed by users through the web application runtime, depending on the scenario.
 
 # Managed service definitions
 
@@ -66,7 +66,7 @@ See **[Service definition reference](/docs/service-definition-reference.md)** fo
 
 ## Phishing attack vulnerability
 
-The redirect pattern used in OAuth 2.0 authorization, is vulnerable to a certain class of phishing attacks. You should not worry about this, if you are a developer who is just getting stared with using "Token Vault". However when you integrate "Token Vault" with your production web application, implementing a post-login redirect pattern is needed to mitigate the said class of vulnerabilities. See **[Phishing attack vulnerability](/docs/phishing-attack-vulnerability.md)** for more details.
+The redirect pattern used in OAuth 2.0 authorization, is vulnerable to a certain class of phishing attacks. You should not worry about this, if you are a developer who is just getting stared with using Token Store. However when you integrate Token Store with your production web application, implementing a post-login redirect pattern is needed to mitigate the said class of vulnerabilities. See **[Phishing attack vulnerability](/docs/phishing-attack-vulnerability.md)** for more details.
 
 # Appendix
 

--- a/docs/management-api-reference.http
+++ b/docs/management-api-reference.http
@@ -4,28 +4,28 @@
 
 @subscriptionId = [your-subscription-id]
 @resourceGroup = [your-resource-group-name]
-@vaultName = [your-vault-name]
+@storeName = [your-store-name]
 @armBaseUrl = https://management.azure.com/subscriptions
-@vaultsPath = {{armBaseUrl}}/{{subscriptionId}}/resourceGroups/{{resourceGroup}}/providers/Microsoft.TokenVault/vaults
+@storesPath = {{armBaseUrl}}/{{subscriptionId}}/resourceGroups/{{resourceGroup}}/providers/Microsoft.Token/stores
 @version = ?api-version=2018-08-01-preview
 @serviceName = testService
 @tokenName = testToken
 @policyName = testPolicy
 
 #########################################################
-###### List vaults
+###### List stores
 #########################################################
  
-GET {{vaultsPath}} 
+GET {{storesPath}} 
     {{version}}
 Authorization: {{$aadToken}}
 
 
 #########################################################
-###### Create or update vault
+###### Create or update store
 #########################################################
  
-PUT {{vaultsPath}}/{{vaultName}}
+PUT {{storesPath}}/{{storeName}}
     {{version}}
 Authorization: {{$aadToken}}
 Content-Type: application/json; charset=utf-8
@@ -40,18 +40,18 @@ Content-Type: application/json; charset=utf-8
 }
 
 #########################################################
-###### Read vault
+###### Read store
 #########################################################
  
-GET {{vaultsPath}}/{{vaultName}}
+GET {{storesPath}}/{{storeName}}
     {{version}}
 Authorization: {{$aadToken}}
 
 #########################################################
-###### Delete vault
+###### Delete store
 #########################################################
  
-DELETE {{vaultsPath}}/{{vaultName}}
+DELETE {{storesPath}}/{{storeName}}
     {{version}}
 Authorization: {{$aadToken}}
 
@@ -59,7 +59,7 @@ Authorization: {{$aadToken}}
 ###### List services
 #########################################################
  
-GET {{vaultsPath}}/{{vaultName}}/services 
+GET {{storesPath}}/{{storeName}}/services 
     {{version}}
 Authorization: {{$aadToken}}
 
@@ -68,7 +68,7 @@ Authorization: {{$aadToken}}
 ###### Create or update service
 #########################################################
  
-PUT {{vaultsPath}}/{{vaultName}}/services/{{serviceName}}
+PUT {{storesPath}}/{{storeName}}/services/{{serviceName}}
     {{version}}
 Authorization: {{$aadToken}}
 Content-Type: application/json; charset=utf-8
@@ -92,7 +92,7 @@ Content-Type: application/json; charset=utf-8
 ###### Read service
 #########################################################
  
-GET {{vaultsPath}}/{{vaultName}}/services/{{serviceName}}
+GET {{storesPath}}/{{storeName}}/services/{{serviceName}}
     {{version}}
 Authorization: {{$aadToken}}
 
@@ -101,7 +101,7 @@ Authorization: {{$aadToken}}
 ###### Delete service
 #########################################################
  
-DELETE {{vaultsPath}}/{{vaultName}}/services/{{serviceName}}
+DELETE {{storesPath}}/{{storeName}}/services/{{serviceName}}
     {{version}}
 Authorization: {{$aadToken}}
 
@@ -110,7 +110,7 @@ Authorization: {{$aadToken}}
 ###### List tokens
 #########################################################
  
-GET {{vaultsPath}}/{{vaultName}}/services/{{serviceName}}/tokens 
+GET {{storesPath}}/{{storeName}}/services/{{serviceName}}/tokens 
     {{version}}
 Authorization: {{$aadToken}}
 
@@ -118,7 +118,7 @@ Authorization: {{$aadToken}}
 ###### Create or update token
 #########################################################
  
-PUT {{vaultsPath}}/{{vaultName}}/services/{{serviceName}}/tokens/{{tokenName}}
+PUT {{storesPath}}/{{storeName}}/services/{{serviceName}}/tokens/{{tokenName}}
     {{version}}
 Authorization: {{$aadToken}}
 Content-Type: application/json; charset=utf-8
@@ -133,7 +133,7 @@ Content-Type: application/json; charset=utf-8
 ###### Read token
 #########################################################
  
-GET {{vaultsPath}}/{{vaultName}}/services/{{serviceName}}/tokens/{{tokenName}}
+GET {{storesPath}}/{{storeName}}/services/{{serviceName}}/tokens/{{tokenName}}
     {{version}}
 Authorization: {{$aadToken}}
 
@@ -141,7 +141,7 @@ Authorization: {{$aadToken}}
 ###### Delete token
 #########################################################
  
-DELETE {{vaultsPath}}/{{vaultName}}/services/{{serviceName}}/tokens/{{tokenName}}
+DELETE {{storesPath}}/{{storeName}}/services/{{serviceName}}/tokens/{{tokenName}}
     {{version}}
 Authorization: {{$aadToken}}
 
@@ -149,7 +149,7 @@ Authorization: {{$aadToken}}
 ###### List access policies
 #########################################################
 
-GET {{vaultsPath}}/{{vaultName}}/accessPolicies
+GET {{storesPath}}/{{storeName}}/accessPolicies
     {{version}}
 Authorization: {{$aadToken}}
 
@@ -157,7 +157,7 @@ Authorization: {{$aadToken}}
 ###### Get access policy
 #########################################################
 
-GET {{vaultsPath}}/{{vaultName}}/accessPolicies/{{policyName}}
+GET {{storesPath}}/{{storeName}}/accessPolicies/{{policyName}}
     {{version}}
 Authorization: {{$aadToken}}
 
@@ -165,7 +165,7 @@ Authorization: {{$aadToken}}
 ###### Create or update access policy
 #########################################################
 
-PUT {{vaultsPath}}/{{vaultName}}/accessPolicies/{{policyName}}
+PUT {{storesPath}}/{{storeName}}/accessPolicies/{{policyName}}
     {{version}}
 Authorization: {{$aadToken}}
 Content-Type: application/json; charset=utf-8
@@ -185,7 +185,7 @@ Content-Type: application/json; charset=utf-8
 ###### Patch access policy
 #########################################################
 
-PATCH {{vaultsPath}}/{{vaultName}}/accessPolicies/{{policyName}}
+PATCH {{storesPath}}/{{storeName}}/accessPolicies/{{policyName}}
     {{version}}
 Authorization: {{$aadToken}}
 Content-Type: application/json; charset=utf-8
@@ -205,6 +205,6 @@ Content-Type: application/json; charset=utf-8
 ###### Delete access policy
 #########################################################
 
-DELETE {{vaultsPath}}/{{vaultName}}/accessPolicies/{{policyName}}
+DELETE {{storesPath}}/{{storeName}}/accessPolicies/{{policyName}}
     {{version}}
 Authorization: {{$aadToken}}

--- a/docs/management-api-reference.md
+++ b/docs/management-api-reference.md
@@ -1,8 +1,8 @@
-> Note: "Token Vault" for App Service is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like "Token Vault" are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
+> Note: Azure Token Store is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like Token Store are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
 
 # Management APIs
 
-The management APIs are primarily meant to enable uniform resource management along with other Azure resources, either through REST-based requests or through deployment templates. They are based on Azure Resource Monitor (ARM) and can be used for programmatic resource mangement actions like read, create, update, delete, list etc. The ARM interface also enables joint template deployment of "Token Vault" and other Azure resoruces for deploying full solutions. These APIs are typically avaiable under `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]`.
+The management APIs are primarily meant to enable uniform resource management along with other Azure resources, either through REST-based requests or through deployment templates. They are based on Azure Resource Monitor (ARM) and can be used for programmatic resource mangement actions like read, create, update, delete, list etc. The ARM interface also enables joint template deployment of Token Store and other Azure resoruces for deploying full solutions. These APIs are typically avaiable under `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]`.
 
 # Calling the APIs with Rest Client extension
 
@@ -20,41 +20,41 @@ The management APIs are primarily meant to enable uniform resource management al
 1. Update the following variables to reflect you own Azure environment.
     1. **`@subscriptionId`** should be set to the your Azure subscription ID.
     1. **`@resourceGroup`** should be set to the a resource you have contributor access to.
-    1. **`@vaultName`** should be set to the name of vault you are managing.
-1. Under the **List Vaults** section, click on the `Send request` link above `GET {{vaultsPath}}`. The *REST Client* extension will walk you through logging into Azure Resource Manager and resolve the value for `{{$aadToken}}`:
+    1. **`@storeName`** should be set to the name of store you are managing.
+1. Under the **List Stores** section, click on the `Send request` link above `GET {{storesPath}}`. The *REST Client* extension will walk you through logging into Azure Resource Manager and resolve the value for `{{$aadToken}}`:
     1. Click on **Sign in** when a VS Code prompts you to sign in. The authorization code will get copied to your clipboard.
     1. Proceed through browser sign in by pasting in the authorization code and proceeding with usual AAD login.
     1. Upon completion of sign in on browser, return to VS code and click **Done**.
     1. The extension might additionally request that you specify your **tenant Id** but this is typically defaulted.
-1. The **Response** window will appear for your HTTP request in VS code containing response code, headers and a body. If working correctly, it will return status code `200 OK` and response body containing a JSON list of the resource group's token vaults.
+1. The **Response** window will appear for your HTTP request in VS code containing response code, headers and a body. If working correctly, it will return status code `200 OK` and response body containing a JSON list of the resource group's token stores.
 
 # Security
 
-All calls to the token vault ARM APIs must bcontain a JWT security token `Authorization` header, where the JWT token in turn contains `"aud": "https://management.azure.com/"`. The principal of this token must also have appropriate access through the resource's Access Control, aka Identity Access Management (IAM) settings.
+All calls to the token store ARM APIs must bcontain a JWT security token `Authorization` header, where the JWT token in turn contains `"aud": "https://management.azure.com/"`. The principal of this token must also have appropriate access through the resource's Access Control, aka Identity Access Management (IAM) settings.
 
 One way to obtain a security token for this purpose is by using the code below, which in turn depends on the `AzureServiceTokenProvider` library.
 
 ```cs
 var azureServiceTokenProvider = new AzureServiceTokenProvider("https://management.azure.com/");
-string securityToken = await azureServiceTokenProvider.GetAccessTokenAsync(TokenVaultResource);
+string securityToken = await azureServiceTokenProvider.GetAccessTokenAsync(TokenStoreResource);
 ```
 
-# "Token Vault" management operations
+# Token Store management operations
 
-## List vaults
+## List stores
 
-Vaults can be listed by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults`. The result should be `200 OK` with a payload similar to below. 
+Stores can be listed by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores`. The result should be `200 OK` with a payload similar to below. 
 
 ```json
 {
   "value": [{
-    "id": "https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/testvault1",
-    "name": "testvault1",
-    "type": "Microsoft.TokenVault/vaults",
+    "id": "https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/teststore1",
+    "name": "teststore1",
+    "type": "Microsoft.Token/stores",
     "location": "westcentralus",
     "properties": {
-      "redirectUrl": "https://testvault1.westcentralus.tokenvault.azure.net/redirect",
-      "vaultUrl": "https://testvault1.westcentralus.tokenvault.azure.net",
+      "redirectUrl": "https://teststore1.westcentralus.tokenstore.azure.net/redirect",
+      "storeUrl": "https://teststore1.westcentralus.tokenstore.azure.net",
       "authorizedPostRedirectUrls": ["http://example.com/tokens/postlogin"]
     },
   },
@@ -63,11 +63,11 @@ Vaults can be listed by requesting a `GET` operation against `https://management
 }
 ```
 
-Try this operation out in VS Code under **List vaults** section of the [.http file](/docs/management-api-reference.http).
+Try this operation out in VS Code under **List stores** section of the [.http file](/docs/management-api-reference.http).
 
-## Create or update vault
+## Create or update store
 
-A vault can be created by requesting a `PUT` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]` with the payload below. The result should be `201 Created`.
+A store can be created by requesting a `PUT` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]` with the payload below. The result should be `201 Created`.
 
 ```json
 {
@@ -80,39 +80,39 @@ A vault can be created by requesting a `PUT` operation against `https://manageme
 }
 ```
 
-Try this operation out in VS Code under **Create or update vault** section of the [.http file](/docs/management-api-reference.http).
+Try this operation out in VS Code under **Create or update store** section of the [.http file](/docs/management-api-reference.http).
 
-## Read vault
+## Read store
 
-A vault can be read by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]`. The resulting payload will be similar to below. 
+A store can be read by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]`. The resulting payload will be similar to below. 
 
 ```json
 {
-    "id": "https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]",
-    "name": "[token-vault-name]",
-    "type": "Microsoft.TokenVault/vaults",
+    "id": "https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]",
+    "name": "[token-store-name]",
+    "type": "Microsoft.Token/stores",
     "location": "westcentralus",
     "properties": {
-      "redirectUrl": "https://[token-vault-name].westcentralus.tokenvault.azure.net:443/redirect",
-      "vaultUrl": "https://[token-vault-name].westcentralus.tokenvault.azure.net",
+      "redirectUrl": "https://[token-store-name].westcentralus.tokenstore.azure.net:443/redirect",
+      "storeUrl": "https://[token-store-name].westcentralus.tokenstore.azure.net",
       "authorizedPostRedirectUrls": ["http://example.com/tokens/postlogin"]
     },
   }
 ```
 
-Try this operation out in VS Code under **Read vault** section of the [.http file](/docs/management-api-reference.http).
+Try this operation out in VS Code under **Read store** section of the [.http file](/docs/management-api-reference.http).
 
-## Delete vault
+## Delete store
 
-A vault can be read by requesting a `DELETE` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]`with no payload. The result should be `200 OK`.
+A store can be read by requesting a `DELETE` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]`with no payload. The result should be `200 OK`.
 
-Try this operation out in VS Code under **Delete vault** section of the [.http file](/docs/management-api-reference.http).
+Try this operation out in VS Code under **Delete store** section of the [.http file](/docs/management-api-reference.http).
 
 # Service management operations
 
 ## Create or update service
 
-A service can be created by requesting a `PUT` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services/[service-name]` with the payload below. The result should be `201 Created`.
+A service can be created by requesting a `PUT` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services/[service-name]` with the payload below. The result should be `201 Created`.
 
 ```json
 {
@@ -135,13 +135,13 @@ Try this operation out in VS Code under **Create or update service** section of 
 
 ## Read service
 
-A service can be read by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services/[service-name]`. The resulting payload will be similar to below. 
+A service can be read by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services/[service-name]`. The resulting payload will be similar to below. 
 
 ```json
 {
-  "id": "/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services/[service-name]",
+  "id": "/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services/[service-name]",
   "name": "[service-name]",
-  "type": "Microsoft.TokenVault/vaults/services",
+  "type": "Microsoft.Token/stores/services",
   "properties": {
     "tokenParameters": {},
     "authentication": {
@@ -158,20 +158,20 @@ Try this operation out in VS Code under **Read service** section of the [.http f
 
 ## Delete service
 
-A service can be read by requesting a `DELETE` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services/[service-name]`with no payload. The result should be `200 OK`.
+A service can be read by requesting a `DELETE` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services/[service-name]`with no payload. The result should be `200 OK`.
 
 Try this operation out in VS Code under **Delete service** section of the [.http file](/docs/management-api-reference.http).
 
 ## List services
 
-Services can be listed by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services`. The result should be `200 OK` with a payload similar to below. 
+Services can be listed by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services`. The result should be `200 OK` with a payload similar to below. 
 
 ```json
 {
   "value": [{
-    "id": "/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services/testservice1",
+    "id": "/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services/testservice1",
     "name": "testservice1",
-    "type": "Microsoft.TokenVault/vaults/services",
+    "type": "Microsoft.Token/stores/services",
     "properties": {
       "tokenParameters": {},
       "authentication": {
@@ -193,19 +193,19 @@ Try this operation out in VS Code under **List services** section of the [.http 
 
 ## List tokens
 
-Tokens can be listed by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services/[service-name]/tokens`. The result should be `200 OK` with a payload similar to below.
+Tokens can be listed by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services/[service-name]/tokens`. The result should be `200 OK` with a payload similar to below.
 
 ```json
 {
   "value": [{
-    "id": "/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services/[service-name]/tokens/testtoken1",
+    "id": "/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services/[service-name]/tokens/testtoken1",
     "name": "testtoken1",
-    "type": "Microsoft.TokenVault/vaults/services/tokens",
+    "type": "Microsoft.Token/stores/services/tokens",
     "location": "westcentralus",
     "properties": {
       "parameterValues": {},
-      "tokenUri": "https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/testtoken1",
-      "loginUri": "https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/testtoken1/login",
+      "tokenUri": "https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/testtoken1",
+      "loginUri": "https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/testtoken1/login",
       "value": null,
       "status": {
         "state": "Error",
@@ -226,7 +226,7 @@ Try this operation out in VS Code under **List tokens** section of the [.http fi
 
 ## Create or update token
 
-A token can be created by requesting a `PUT` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services/[service-name]/tokens/[token-name]` with the payload below. The result should be `201 Created`.
+A token can be created by requesting a `PUT` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services/[service-name]/tokens/[token-name]` with the payload below. The result should be `201 Created`.
 
 ```json
 {
@@ -240,17 +240,17 @@ Try this operation out in VS Code under **Create or update service** section of 
 
 ## Read token
 
-A token can be read by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services/[service-name]/tokens/[token-name]`. The resulting payload will be similar to below.
+A token can be read by requesting a `GET` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services/[service-name]/tokens/[token-name]`. The resulting payload will be similar to below.
 
 ```json
 {
-  "id": "/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services/[service-name]/tokens/testtoken",
+  "id": "/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services/[service-name]/tokens/testtoken",
   "name": "testtoken",
-  "type": "Microsoft.TokenVault/vaults/services/tokens",
+  "type": "Microsoft.Token/stores/services/tokens",
   "properties": {
      "parameterValues": {},
-    "tokenUri": "https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/testtoken",
-    "loginUri": "https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/testtoken/login",
+    "tokenUri": "https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/testtoken",
+    "loginUri": "https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/testtoken/login",
     "value": null,
     "status": {
       "state": "Error",
@@ -268,6 +268,6 @@ Try this operation out in VS Code under **Read token** section of the [.http fil
 
 ## Delete token
 
-A token can be read by requesting a `DELETE` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.TokenVault/vaults/[token-vault-name]/services/[service-name]/tokens/[token-name]`with no payload. The result should be `200 OK`.
+A token can be read by requesting a `DELETE` operation against `https://management.azure.com/subscriptions/[subscription-id]/resourceGroups/[resource-group]/providers/Microsoft.Token/stores/[token-store-name]/services/[service-name]/tokens/[token-name]`with no payload. The result should be `200 OK`.
 
 Try this operation out in VS Code under **Delete token** section of the [.http file](/docs/management-api-reference.http).

--- a/docs/phishing-attack-vulnerability.md
+++ b/docs/phishing-attack-vulnerability.md
@@ -1,10 +1,10 @@
-> Note: "Token Vault" for App Service is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like "Token Vault" are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
+> Note: Azure Token Store is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like Token Store are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
 
 # Phishing attack vulnerablity
 
 ## "Getting started" development experience
 
-The redirect pattern used in OAuth 2.0 to enable a web application to access an external service on behalf of a user, also introduces a specific vulnerabilty to phishing attacks. The "getting started" development experience introduced in our [**Using "Token Vault" from an App Service Site**](https://github.com/joerob-msft/app-service-msi-tokenvault-dotnet) topic, introduces a **confirmation dialog** that somewhat mitigates the attack described below, while keeping the initial development experience simple. You can see the "getting started" development sequence below:
+The redirect pattern used in OAuth 2.0 to enable a web application to access an external service on behalf of a user, also introduces a specific vulnerabilty to phishing attacks. The "getting started" development experience introduced in our [**Using Token Store from an App Service Site**](https://github.com/joerob-msft/app-service-msi-tokenvault-dotnet) topic, introduces a **confirmation dialog** that somewhat mitigates the attack described below, while keeping the initial development experience simple. You can see the "getting started" development sequence below:
 
 ![](https://raw.githubusercontent.com/Azure/azure-tokens/master/docs/phishing-attack-vulnerability/development-sequence-diagram.png "Development sequence diagram")
 
@@ -16,6 +16,6 @@ For production deployment scenarios however, the developer needs to be fully awa
 
 ## Phishing attack mitigation
 
-To mitigate the attack, the developer of the web application will have to specify and implement a **post-login redirect URI**, which will be responsible for validating that the redirected sequence of pages was indeed initiated from the same session, then explicitly call save for the user's token. The implementation is not trivial and requires understanding the concepts around web application session state, and possibly the parameters passed throughout the redirects. We have provided a sample implementation of this pattern through our [Advanced "Token Vault" for App Service](https://github.com/joerob-msft/app-service-tokenvault-advanced) sample. The diagram below describes the ideal implementaion in general, which elliminates the *confirmation dialog* from the "getting started" development implemenation from the user experience.
+To mitigate the attack, the developer of the web application will have to specify and implement a **post-login redirect URI**, which will be responsible for validating that the redirected sequence of pages was indeed initiated from the same session, then explicitly call save for the user's token. The implementation is not trivial and requires understanding the concepts around web application session state, and possibly the parameters passed throughout the redirects. We have provided a sample implementation of this pattern through our [Advanced Token Store for App Service](https://github.com/joerob-msft/app-service-tokenvault-advanced) sample. The diagram below describes the ideal implementaion in general, which elliminates the *confirmation dialog* from the "getting started" development implemenation from the user experience.
 
 ![](https://raw.githubusercontent.com/Azure/azure-tokens/master/docs/phishing-attack-vulnerability/production-sequence-diagram.png "Production sequence diagram")

--- a/docs/runtime-access-policy.md
+++ b/docs/runtime-access-policy.md
@@ -1,3 +1,3 @@
-> Note: "Token Vault" for App Service is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like "Token Vault" are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
+> Note: Azure Token Store is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like Token Store are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
 
 # [Coming soon]

--- a/docs/runtime-api-reference.http
+++ b/docs/runtime-api-reference.http
@@ -4,10 +4,10 @@
 
 @subscriptionId = [your-subscription-id]
 @resourceGroup = [your-resource-group-name]
-@vaultName = [your-vault-name]
+@storeName = [your-store-name]
 @serviceName = testService
 @tokenName = testToken
-@runtimeBaseUrl = https://{{vaultName}}.westcentralus.tokenvault.azure.net
+@runtimeBaseUrl = https://{{storeName}}.westcentralus.tokenstore.azure.net
 
 ## NOTE: REPLACE [your-domain.com] WITH YOUR DOMAIN NAME. For example if your personal user Id is me@mycompany.com,
 ## the string [your-domain.com] should be replaced with mycompany.com everywhere in this document
@@ -17,14 +17,14 @@
 #########################################################
 
 GET {{runtimeBaseUrl}}/services/{{serviceName}}/tokens/{{tokenName}}
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 #########################################################
 ###### List tokens
 #########################################################
 
 GET {{runtimeBaseUrl}}/services/{{serviceName}}/tokens
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 
 #########################################################
@@ -32,21 +32,21 @@ Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
 #########################################################
 
 POST {{runtimeBaseUrl}}/services/{{serviceName}}/tokens/{{tokenName}}
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 #########################################################
 ###### Get access token
 #########################################################
 
 POST {{runtimeBaseUrl}}/services/{{serviceName}}/tokens/{{tokenName}}/accesstoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 #########################################################
 ###### Save token using redirect code
 #########################################################
 
 POST {{runtimeBaseUrl}}/services/{{serviceName}}/tokens/{{tokenName}}/save
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 { "code" : "" }
@@ -56,14 +56,14 @@ Content-Type: application/json; charset=utf-8
 #########################################################
 
 GET {{runtimeBaseUrl}}/services
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 #########################################################
 ###### Read service
 #########################################################
 
 GET {{runtimeBaseUrl}}/services/{{serviceName}}
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 
 #########################################################
@@ -71,7 +71,7 @@ Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
 #########################################################
  
 PUT {{runtimeBaseUrl}}/services/{{serviceName}}
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 {

--- a/docs/runtime-api-reference.md
+++ b/docs/runtime-api-reference.md
@@ -1,8 +1,8 @@
-> Note: "Token Vault" for App Service is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like "Token Vault" are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
+> Note: Azure Token Store is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like Token Store are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
 
 # What are runtime APIs?
 
-The runtime APIs are available through a dedicated web address for each token vault. They provide token operations like get-valid-token, in addition to supporting most of the resource management actions. Runtime APIs are meant for direct programmatic access and are better optimized for performance. The service host is typically available at `https://[token-vault-name].westcentralus.tokenvault.azure.net`.
+The runtime APIs are available through a dedicated web address for each token store. They provide token operations like get-valid-token, in addition to supporting most of the resource management actions. Runtime APIs are meant for direct programmatic access and are better optimized for performance. The service host is typically available at `https://[token-store-name].westcentralus.tokenstore.azure.net`.
 
 # Calling the APIs with Rest Client extension
 
@@ -20,36 +20,36 @@ The runtime APIs are available through a dedicated web address for each token va
 1. Update the following variables to reflect you own Azure environment.
     1. **`@subscriptionId`** should be set to the your Azure subscription ID.
     1. **`@resourceGroup`** should be set to the a resource you have contributor access to.
-    1. **`@vaultName`** should be set to the vault name you are interacting with.
+    1. **`@storeName`** should be set to the store name you are interacting with.
     1. Replace `[your-domain.com]` with your domainname. For example if your personal user Id is *me@mycompany.com*, the string [your-domain.com] should be replaced with `mycompany.com` everywhere in the `.http` document.
-1. Under the **Read token** section, click on the `Send request` link above `GET {{runtimeBaseUrl}}/services/{{serviceName}}/tokens/{{tokenName}}`. The *REST Client* extension will walk you through logging into Azure Resource Manager and resolve the value for `{{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}`:
+1. Under the **Read token** section, click on the `Send request` link above `GET {{runtimeBaseUrl}}/services/{{serviceName}}/tokens/{{tokenName}}`. The *REST Client* extension will walk you through logging into Azure Resource Manager and resolve the value for `{{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}`:
     1. Click on **Sign in** when a VS Code prompts you to sign in. The authorization code will get copied to your clipboard.
     1. Proceed through browser sign in by pasting in the authorization code and proceeding with usual AAD login.
     1. Upon completion of sign in on browser, return to VS code and click **Done**.
-1. The **Response** window will appear for your HTTP request in VS code containing response code, headers and a body. If working correctly, it will return status code `200 OK` and response body containing a JSON list of the resource group's token vaults.
+1. The **Response** window will appear for your HTTP request in VS code containing response code, headers and a body. If working correctly, it will return status code `200 OK` and response body containing a JSON list of the resource group's token stores.
 
 # Security
 
-All calls to the token vault ARM APIs must bcontain a JWT security token `Authorization` header, where the JWT token in turn contains `"aud": "https://tokenvault.azure.net"`. The principal of this token must also have appropriate access through the Token Vault's access policy security model. See [Access Policy](/docs/access-policy-runtime-security.md) for more details on how this security model works.
+All calls to the token store ARM APIs must bcontain a JWT security token `Authorization` header, where the JWT token in turn contains `"aud": "https://tokenstore.azure.net"`. The principal of this token must also have appropriate access through the Token Store's access policy security model. See [Access Policy](/docs/access-policy-runtime-security.md) for more details on how this security model works.
 
 One way to obtain a security token for this purpose is by using the code below, which in turn depends on the `AzureServiceTokenProvider` library.
 
 ```cs
-var azureServiceTokenProvider = new AzureServiceTokenProvider("https://tokenvault.azure.net");
-string securityToken = await azureServiceTokenProvider.GetAccessTokenAsync(TokenVaultResource);
+var azureServiceTokenProvider = new AzureServiceTokenProvider("https://tokenstore.azure.net");
+string securityToken = await azureServiceTokenProvider.GetAccessTokenAsync(TokenStoreResource);
 ```
 
 In the accompanying [.http file](/docs/runtime-api-reference.http), this header is automatically generated and sent as part of the Authorization header using the expression below.
 
 ```http
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 ```
 
 # Token runtime operations
 
 ## Create or update token
 
-A token can be created by requesting a `PUT` operation against `https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/[token-name]` with the payload below. The result should be `201 Created`.
+A token can be created by requesting a `PUT` operation against `https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/[token-name]` with the payload below. The result should be `201 Created`.
 
 ```json
 {
@@ -63,15 +63,15 @@ Try this operation out in VS Code under **Create or update token** section of th
 
 ## Read token
 
-A token can be read by requesting a `GET` operation against `https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/[token-name]`. The resulting payload will be similar to below:
+A token can be read by requesting a `GET` operation against `https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/[token-name]`. The resulting payload will be similar to below:
 
 ```json
 {
     "name": "testtoken",
     "displayName": "testToken" , 
     "parameterValues": {},
-    "tokenUri": "https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/testtoken",
-    "loginUri": "https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/testtoken/login",
+    "tokenUri": "https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/testtoken",
+    "loginUri": "https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/testtoken/login",
     "value": null,
     "status": {
         "state": "Error",
@@ -88,15 +88,15 @@ Try this operation out in VS Code under **Read token** section of the [.http fil
 
 ## Get valid access token
 
-A token can be retrieved by requesting a `POST` operation against `https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/[token-name]` with the an empty body payload. The result should be `200 OK`.
+A token can be retrieved by requesting a `POST` operation against `https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/[token-name]` with the an empty body payload. The result should be `200 OK`.
 
 Try this operation out in VS Code under **Get valid access token** section of the [.http file](/docs/runtime-api-reference.http).
 
-Alternately, an access token only without the token metadata can be retrieved by requesting a `POST` operation against `https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/[token-name]/accesstoken` with the an empty body payload. The result should be `200 OK`.
+Alternately, an access token only without the token metadata can be retrieved by requesting a `POST` operation against `https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/[token-name]/accesstoken` with the an empty body payload. The result should be `200 OK`.
 
 ## Save token (after post-login redirect)
 
-Fully secure integration of "Token Vault" with you web application, requires implementing the post-login redirect pattern. Please refer to the [Phishing attack vulnerability](phishing-attack-vulnerability.md) topic for the reasons why this is required. The said pattern includes a last step of saving the token by requesting a `POST` operation against `https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/[token-name]/save` with the payload below. The result should be `200 OK`.
+Fully secure integration of Token Store with your web application requires implementing the post-login redirect pattern. Please refer to the [Phishing attack vulnerability](phishing-attack-vulnerability.md) topic for the reasons why this is required. The said pattern includes a last step of saving the token by requesting a `POST` operation against `https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/[token-name]/save` with the payload below. The result should be `200 OK`.
 
 ```json
 {
@@ -120,13 +120,13 @@ Try this operation out in VS Code under **Save token** section of the [.http fil
 
 ## Delete token
 
-A token can be read by requesting a `DELETE` operation against `https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/[token-name]`with no payload. The result should be `200 OK`.
+A token can be read by requesting a `DELETE` operation against `https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/[token-name]`with no payload. The result should be `200 OK`.
 
 Try this operation out in VS Code under **Delete token** section of the [.http file](/docs/runtime-api-reference.http).
 
 ## List tokens
 
-Tokens can be listed by requesting a `GET` operation against `https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens`. The result should be `200 OK` with a payload similar to below. 
+Tokens can be listed by requesting a `GET` operation against `https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens`. The result should be `200 OK` with a payload similar to below. 
 
 ```json
 {
@@ -134,8 +134,8 @@ Tokens can be listed by requesting a `GET` operation against `https://[token-vau
     "name": "testtoken1",
     "displayName": "Test token 1",
     "parameterValues": {},
-    "tokenUri": "https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/testtoken1",
-    "loginUri": "https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]/tokens/testtoken1/login",
+    "tokenUri": "https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/testtoken1",
+    "loginUri": "https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]/tokens/testtoken1/login",
     "value": null,
     "status": {
     "state": "Error",
@@ -157,7 +157,7 @@ Try this operation out in VS Code under **List tokens** section of the [.http fi
 
 ## Create or update service
 
-A service can be created by requesting a `PUT` operation against `https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]` with the payload below. The result should be `201 Created`.
+A service can be created by requesting a `PUT` operation against `https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]` with the payload below. The result should be `201 Created`.
 
 ```json
 {
@@ -178,7 +178,7 @@ Try this operation out in VS Code under **Create or update service** section of 
 
 ## Read service
 
-A service can be read by requesting a `GET` operation against `https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]`. The resulting payload will be similar to below. 
+A service can be read by requesting a `GET` operation against `https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]`. The resulting payload will be similar to below. 
 
 ```json
 {
@@ -196,13 +196,13 @@ Try this operation out in VS Code under **Read service** section of the [.http f
 
 ## Delete service
 
-A service can be read by requesting a `DELETE` operation against `https://[token-vault-name].westcentralus.tokenvault.azure.net/services/[service-name]`with no payload. The result should be `200 OK`.
+A service can be read by requesting a `DELETE` operation against `https://[token-store-name].westcentralus.tokenstore.azure.net/services/[service-name]`with no payload. The result should be `200 OK`.
 
 Try this operation out in VS Code under **Delete service** section of the [.http file](/docs/runtime-api-reference.http).
 
 ## List services
 
-Services can be listed by requesting a `GET` operation against `https://[token-vault-name].westcentralus.tokenvault.azure.net/services`. The result should be `200 OK` with a payload similar to below.
+Services can be listed by requesting a `GET` operation against `https://[token-store-name].westcentralus.tokenstore.azure.net/services`. The result should be `200 OK` with a payload similar to below.
 
 ```json
 {

--- a/docs/service-definition-reference.http
+++ b/docs/service-definition-reference.http
@@ -4,10 +4,10 @@
 
 @subscriptionId = [your-subscription-id]
 @resourceGroup = [your-resource-group-name]
-@vaultName = [your-vault-name]
+@storeName = [your-store-name]
 @serviceName = testService
 @tokenName = testToken
-@runtimeBaseUrl = https://{{vaultName}}.westcentralus.tokenvault.azure.net
+@runtimeBaseUrl = https://{{storeName}}.westcentralus.tokenstore.azure.net
 
 ## NOTE: REPLACE [your-domain.com] WITH YOUR DOMAIN NAME. For example if your personal user Id is me@mycompany.com,
 ## the string [your-domain.com] should be replaced with mycompany.com everywhere in this document
@@ -17,7 +17,7 @@
 #########################################################
  
 PUT {{runtimeBaseUrl}}/services/dropbox{{serviceName}}
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 {
@@ -36,7 +36,7 @@ Content-Type: application/json; charset=utf-8
 ### Create token.
 
 PUT {{runtimeBaseUrl}}/services/dropbox{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 {
@@ -46,7 +46,7 @@ Content-Type: application/json; charset=utf-8
 ### Authenticate and get access token.
 
 POST {{runtimeBaseUrl}}/services/dropbox{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 ### Call dropbox with acces stoken.
 POST https://api.dropboxapi.com/2/files/list_folder
@@ -60,7 +60,7 @@ Content-Type: application/json
 #########################################################
 
 PUT {{runtimeBaseUrl}}/services/aad{{serviceName}}
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 {
@@ -86,7 +86,7 @@ Content-Type: application/json; charset=utf-8
 ### Create token.
 
 PUT {{runtimeBaseUrl}}/services/aad{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 { 
@@ -96,7 +96,7 @@ Content-Type: application/json; charset=utf-8
 ### Authenticate and get access token.
 
 POST {{runtimeBaseUrl}}/services/aad{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 ### Call AAD graph using access token.
 
@@ -118,7 +118,7 @@ Authorization: Bearer [your-aad-access-token]
 #########################################################
 
 PUT {{runtimeBaseUrl}}/services/linkedin{{serviceName}}
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 {
@@ -139,7 +139,7 @@ Content-Type: application/json; charset=utf-8
 ### Create token.
 
 PUT {{runtimeBaseUrl}}/services/linkedin{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 { 
@@ -149,7 +149,7 @@ Content-Type: application/json; charset=utf-8
 ### Authenticate and get access token.
 
 POST {{runtimeBaseUrl}}/services/linkedin{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 ### Call outlook using access token.
 ### Reference: https://docs.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow?context=linkedin/consumer/context
@@ -162,7 +162,7 @@ Authorization: Bearer [your-linkedin-access-token]
 #########################################################
  
 PUT {{runtimeBaseUrl}}/services/instagram{{serviceName}}
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 {
@@ -182,7 +182,7 @@ Content-Type: application/json; charset=utf-8
 ### Create token.
 
 PUT {{runtimeBaseUrl}}/services/instagram{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 {
@@ -192,7 +192,7 @@ Content-Type: application/json; charset=utf-8
 ### Authenticate and get access token.
 
 POST {{runtimeBaseUrl}}/services/instagram{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 ### Call instagram using access token
 
@@ -202,7 +202,7 @@ GET https://api.instagram.com/v1/users/self/?access_token=[your-instagram-access
 ###### Create OAuth 2.0 generic service - with dropbox
 #########################################################
 PUT {{runtimeBaseUrl}}/services/oauth2generic{{serviceName}}
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 {
@@ -229,7 +229,7 @@ Content-Type: application/json; charset=utf-8
 ### Create token.
 
 PUT {{runtimeBaseUrl}}/services/oauth2generic{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 {
@@ -239,7 +239,7 @@ Content-Type: application/json; charset=utf-8
 ### Autheticate and get access token.
 
 POST {{runtimeBaseUrl}}/services/oauth2generic{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 ### Call OAuth2 generic service using access token.
 
@@ -254,7 +254,7 @@ Content-Type: application/json
 #########################################################
 
 PUT {{runtimeBaseUrl}}/services/twitter{{serviceName}}
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 {
@@ -275,7 +275,7 @@ Content-Type: application/json; charset=utf-8
 ### Create token.
 
 PUT {{runtimeBaseUrl}}/services/twitter{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 { 
@@ -285,7 +285,7 @@ Content-Type: application/json; charset=utf-8
 ### Authenticate and get access token.
 
 POST {{runtimeBaseUrl}}/services/twitter{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 ### Call outlook using access token.
 ### Reference - https://developer.twitter.com/en/docs/basics/authentication/overview/3-legged-oauth
@@ -298,7 +298,7 @@ Authorization: Bearer [your-twitter-access-token]
 #########################################################
 
 PUT {{runtimeBaseUrl}}/services/facebook{{serviceName}}
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 {
@@ -319,7 +319,7 @@ Content-Type: application/json; charset=utf-8
 ### Create token.
 
 PUT {{runtimeBaseUrl}}/services/facebook{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 Content-Type: application/json; charset=utf-8
 
 { 
@@ -329,7 +329,7 @@ Content-Type: application/json; charset=utf-8
 ### Authenticate and get access token.
 
 POST {{runtimeBaseUrl}}/services/facebook{{serviceName}}/tokens/testtoken
-Authorization: {{$aadToken [your-domain.com] aud:https://tokenvault.azure.net}}
+Authorization: {{$aadToken [your-domain.com] aud:https://tokenstore.azure.net}}
 
 ### Call outlook using access token.
 ### Reference:  https://developers.facebook.com/docs/graph-api/using-graph-api/

--- a/docs/service-definition-reference.md
+++ b/docs/service-definition-reference.md
@@ -1,8 +1,8 @@
-> Note: "Token Vault" for App Service is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like "Token Vault" are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
+> Note: Azure Token Store is in Private Preview, and can be accessed by contacting our team, and completing the onboarding process under NDA. Private Preview features like Token Store are primarily meant to gather feedback, and should not be used in production. Support may be discontinued in the future.
 
 # General recipe for creating services
 
-In order to take advantage of "Token Vault" against an external service (e.g. Dropbox), you first need to create a developer account them. The corresponding service will have a direct relationship with you as the app developer and can notify you of issues or unusual activity. The can also enforce security and usability limits on a per-application basis.
+In order to take advantage of Token Store against an external service (e.g. Dropbox), you first need to create a developer account them. The corresponding service will have a direct relationship with you as the app developer and can notify you of issues or unusual activity. The can also enforce security and usability limits on a per-application basis.
 
 The following are the general set of steps required to create a service resource:
 
@@ -12,12 +12,12 @@ Register an app with the service (eg Dropbox) you want to call on behalf of your
 
 1. Go to the service's **Developer site**. For example visit the [Dropbox developer site](https://www.dropbox.com/developers/apps).
 1. create an account with the service using your contact information.
-1. Create an app registration, and set the redirect URI to `https://[your-vault-name].westcentralus.tokenvault.azure.net/redirect`.
+1. Create an app registration, and set the redirect URI to `https://[your-store-name].westcentralus.tokenstore.azure.net/redirect`.
 1. Record the **App key** and **App secret** to be used in upcoming steps.
 
 ## Create the service resource
 
-You can create a service using ARM templates, or programmatically from the runtime. For ARM template creation and deployment refer to [this guide](https://github.com/joerob-msft/app-service-msi-tokenvault-dotnet), and specifically [this template](https://github.com/joerob-msft/app-service-msi-tokenvault-dotnet/blob/master/azuredeploy.json). To programmatically create the service resource refer to the **Create service** section under  [Runtime API reference](/docs/runtime-api-reference.md) or [Management API reference](/docs/management-api-reference.md).
+You can create a service using ARM templates, or programmatically from the runtime. For ARM template creation and deployment refer to [this guide](https://github.com/joerob-msft/app-service-msi-tokenstore-dotnet), and specifically [this template](https://github.com/joerob-msft/app-service-msi-tokenstore-dotnet/blob/master/azuredeploy.json). To programmatically create the service resource refer to the **Create service** section under  [Runtime API reference](/docs/runtime-api-reference.md) or [Management API reference](/docs/management-api-reference.md).
 
 You need to set the following parameters on the service:
 
@@ -67,7 +67,7 @@ The following instructions describe the service creation steps that may be diffe
 1. **Sign in** using the link on top-right of the web site. **[Sign up](https://www.dropbox.com/register)** if you do not have an account already.
 1. [Create a new app](https://www.dropbox.com/developers/apps/create), choose **Dropbox API**, **Full Dropbox** access, and create a unique name for your app.
 1. Record the **App key** and **App secret** values for future use.
-1. Add to **Redirect URIs** the value `https://[token-vault-name].westcentralus.tokenvault.azure.net/redirect` where `[token-vault-name]` is the name of your token vault, that you will create in the next step.
+1. Add to **Redirect URIs** the value `https://[token-store-name].westcentralus.tokenstore.azure.net/redirect` where `[token-store-name]` is the name of your token store, that you will create in the next step.
 1. Follow instrictions to **Create the service** above.
 
 Try this operation out in VS Code under **Create Dropbox service** section of the [.http file](/docs/service-definition-reference.http). See the [Runtime API reference](/docs/runtime-api-reference.cs) topic for instructions on how to use the `.http` file with VS Code's Rest Client extension.
@@ -77,7 +77,7 @@ Try this operation out in VS Code under **Create Dropbox service** section of th
 The following instructions describe the service creation steps that may be different from the general recipe presented above.
 
 1. Go to [Azure Portal application registration](https://portal.azure.com/#blade/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/RegisteredApps).
-1. Create a new application, Use a unique name for your app, select **Application type** *Web app / API*, and set sign-on URL to `https://[token-vault-name].westcentralus.tokenvault.azure.net/redirect` where `[token-vault-name]` is the name of your token vault, that you will create in the next step.
+1. Create a new application, Use a unique name for your app, select **Application type** *Web app / API*, and set sign-on URL to `https://[token-store-name].westcentralus.tokenstore.azure.net/redirect` where `[token-store-name]` is the name of your token store, that you will create in the next step.
 1. After creation record the **Application ID** values for future use.
 1. Select **Settings**, then **Keys**, enter a *Key description*, select **Expires** value *Never*, then *Save*.
 1. Record the Key Password Value (or **Application secret**) for future use. Note: This is the only time you will be able to retrieve the secret from the Azure portal UI.
@@ -119,9 +119,9 @@ The OAuth 2.0 generic service can by used to create a customized service reosurc
 
 1. Follow instrictions to **Create the service** above. The payload for DropBox for example will look something like below:
     1. Set `clientid` and `clientsecret` to the **Client ID** and **Client Secret** values you obtained from the external service.
-    1. Set the `AuthorizationUrlTemplate` and `AuthorizationUrlQueryStringTemplate` to represent the URI "Token Vault" will redirect to on the external service.
-    1. Set the `TokenUrlTemplate` and `TokenBodyTemplate` to describe the URI and data "Token Vault" uses to get the refresh token from the external service.
-    1. Set the `RefreshUrlTemplate` and `RefreshBodyTemplate` to represent the URI and data "Token Vault" uses to get a refreshed token from the external service.
+    1. Set the `AuthorizationUrlTemplate` and `AuthorizationUrlQueryStringTemplate` to represent the URI Token Store will redirect to on the external service.
+    1. Set the `TokenUrlTemplate` and `TokenBodyTemplate` to describe the URI and data "Token Store uses to get the refresh token from the external service.
+    1. Set the `RefreshUrlTemplate` and `RefreshBodyTemplate` to represent the URI and data Token Store uses to get a refreshed token from the external service.
 
 ```js
 {
@@ -156,7 +156,7 @@ The following instructions describe the service creation steps that may be diffe
 1. **Sign in** using the link on top-right of the web site.
 1. Create a new application, by choosing a unique name for your app.
 1. Record the **App ID** and **App secret** values for future use.
-1. Add the **Facebook Login** product on the first page, and under **Settings**, set **Valid OAuth Redirect URIs** to `https://[token-vault-name].westcentralus.tokenvault.azure.net/redirect` where `[token-vault-name]` is the name of your token vault, that you will create in the next step.
+1. Add the **Facebook Login** product on the first page, and under **Settings**, set **Valid OAuth Redirect URIs** to `https://[token-store-name].westcentralus.tokenstore.azure.net/redirect` where `[token-store-name]` is the name of your token store, that you will create in the next step.
 1. Set rest of the required fields like *Privacy policy URL*, then *Save changes*.
 1. Follow instrictions to **Create the service** above.
 
@@ -171,7 +171,7 @@ The following instructions describe the service creation steps that may be diffe
 1. **Sign in** using the link on top-right of the web site.
 1. Create a new client, by choosing a unique name for your app.
 1. Record the **Client ID** and **Client Secret** values for future use.
-1. Under **Security** tab, set **Valid redirect URIs** to `https://[token-vault-name].westcentralus.tokenvault.azure.net/redirect` where `[token-vault-name]` is the name of your token vault, that you will create in the next step.
+1. Under **Security** tab, set **Valid redirect URIs** to `https://[token-store-name].westcentralus.tokenstore.azure.net/redirect` where `[token-store-name]` is the name of your token store, that you will create in the next step.
 1. Set rest of the required fields like *Company name*, then *Save changes*.
 1. Follow instrictions to **Create the service** above, but make sure the parameter `scopes` is set to `basic`.
 


### PR DESCRIPTION
Update documentation to reflect the new naming
Token Vault is now Token Store

Resource Provider type on management plane is Microsoft.Token

Runtime audience and dns name is not tokenstore.azure.net

vault resource is renamed to store

These code changes have already been made on the backend and can/should be used now.